### PR TITLE
Masonry icon - fix for active state icon path

### DIFF
--- a/app/assets/stylesheets/_search_results.scss
+++ b/app/assets/stylesheets/_search_results.scss
@@ -142,7 +142,7 @@
 
   &.active {
     .masonry-icon {
-      background: image-url('icons/icon-masonry-white.svg');
+      background-image: image-url('icons/icon-masonry-white.svg');
     }
   }
 }

--- a/app/assets/stylesheets/_search_results.scss
+++ b/app/assets/stylesheets/_search_results.scss
@@ -135,14 +135,14 @@
 .view-type-masonry {
   .masonry-icon {
     display: block;
-    background: url(<%= asset_path 'icons/icon-masonry.svg' %>);
+    background-image: image-url('icons/icon-masonry.svg');
     height: 15px;
     width: 14px;
   }
 
   &.active {
     .masonry-icon {
-      background: url(icons/icon-masonry-white.svg);
+      background: image-url('icons/icon-masonry-white.svg');
     }
   }
 }


### PR DESCRIPTION
Use different asset path helper method to be consistent